### PR TITLE
fix: cache sender public key and address

### DIFF
--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -27,6 +27,8 @@ import type {
 import type { BigIntLike } from '@nomicfoundation/ethereumjs-util'
 
 interface TransactionCache {
+  senderAddress: Address | undefined
+  senderPublicKey: Buffer | undefined
   hash: Buffer | undefined
   dataFee?: {
     value: bigint
@@ -57,6 +59,8 @@ export abstract class BaseTransaction<TransactionObject> {
   public readonly common!: Common
 
   protected cache: TransactionCache = {
+    senderAddress: undefined,
+    senderPublicKey: undefined,
     hash: undefined,
     dataFee: undefined,
   }
@@ -291,13 +295,23 @@ export abstract class BaseTransaction<TransactionObject> {
    * Returns the sender's address
    */
   getSenderAddress(): Address {
-    return new Address(publicToAddress(this.getSenderPublicKey()))
+    if (this.cache.senderAddress === undefined) {
+      this.cache.senderAddress = new Address(publicToAddress(this.getSenderPublicKey()))
+    }
+    return this.cache.senderAddress
   }
+
+  abstract _getSenderPublicKey(): Buffer
 
   /**
    * Returns the public key of the sender
    */
-  abstract getSenderPublicKey(): Buffer
+  getSenderPublicKey(): Buffer {
+    if (this.cache.senderPublicKey === undefined) {
+      this.cache.senderPublicKey = this._getSenderPublicKey()
+    }
+    return this.cache.senderPublicKey
+  }
 
   /**
    * Signs a transaction.

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -338,7 +338,7 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMarketEIP155
   /**
    * Returns the public key of the sender
    */
-  public getSenderPublicKey(): Buffer {
+  _getSenderPublicKey(): Buffer {
     if (!this.isSigned()) {
       const msg = this._errorMsg('Cannot call this method if transaction is not signed')
       throw new Error(msg)

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -308,7 +308,7 @@ export class AccessListEIP2930Transaction extends BaseTransaction<AccessListEIP2
   /**
    * Returns the public key of the sender
    */
-  public getSenderPublicKey(): Buffer {
+  _getSenderPublicKey(): Buffer {
     if (!this.isSigned()) {
       const msg = this._errorMsg('Cannot call this method if transaction is not signed')
       throw new Error(msg)

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -291,7 +291,7 @@ export class Transaction extends BaseTransaction<Transaction> {
   /**
    * Returns the public key of the sender
    */
-  getSenderPublicKey(): Buffer {
+  _getSenderPublicKey(): Buffer {
     const msgHash = this.getMessageToVerifySignature()
 
     const { v, r, s } = this


### PR DESCRIPTION
Improve performance in Hardhat by caching the sender public key and address computation on transactions. 

I cannot run tests locally with or without this change, but I tested the changes by linking with local Hardhat where it improves performance for `eth_sendTransaction` by at least 22%.